### PR TITLE
Storage Subscripts and Request.storage Method

### DIFF
--- a/Sources/Helpers/Request+Storage.swift
+++ b/Sources/Helpers/Request+Storage.swift
@@ -39,4 +39,12 @@ extension Request {
         let storage = try self.privateContainer.make(Storage.self)
         storage.cache[key] = value
     }
+    
+    /// Gets the `Storage` instance from the
+    /// request's private container.
+    ///
+    /// - Returns: The request's private `Storage` instance.
+    public func storage()throws -> Storage {
+        return try self.privateContainer.make(Storage.self)
+    }
 }

--- a/Sources/Helpers/Storage.swift
+++ b/Sources/Helpers/Storage.swift
@@ -11,4 +11,54 @@ public class Storage: Service {
     
     ///
     public init() {}
+    
+    /// Allows accessing stored values with
+    /// `storage[key]` syntax.
+    ///
+    /// - Parameter key: The key of the value to fetch.
+    ///
+    /// - Returns: The value stored for the key passed in.
+    public subscript (_ key: String) -> Any? {
+        get {
+            return self.cache[key] ?? nil
+        }
+        set {
+            self.cache[key] = newValue
+        }
+    }
+    
+    /// Allows accessing stored values with
+    /// `storage[key]` syntax as a specific type.
+    ///
+    /// - Parameters:
+    ///   - key: The key of the value to fetch.
+    ///   - type: The type to convert the stored value to.
+    ///
+    /// - Returns: The value stored for the key passed in.
+    public subscript <T>(_ key: String, as type: T.Type) -> T? {
+        get {
+            let value = self.cache[key] ?? nil
+            return value as? T
+        }
+        set {
+            self.cache[key] = newValue
+        }
+    }
+    
+    /// Allows accessing stored values with
+    /// `storage[key]` syntax as a specific type.
+    ///
+    /// - Parameters:
+    ///   - key: The key of the value to fetch.
+    ///
+    /// - Returns: The value stored for the key passed in.
+    public subscript <T>(_ key: String) -> T? {
+        get {
+            let value = self.cache[key] ?? nil
+            return value as? T
+        }
+        set {
+            self.cache[key] = newValue
+        }
+    }
 }


### PR DESCRIPTION
Adds subscript methods to the `Storage` type:

- `storage[key] -> Any?`
- `storage[key, as: Type.self] -> Type?`
- `storage[key] -> Type?`

And a `.storage` method to `Request`:

- `request.storage()throws -> Storage`